### PR TITLE
[AI Policy] add acronyms to dictionary

### DIFF
--- a/resources/dictionary.txt
+++ b/resources/dictionary.txt
@@ -12,6 +12,7 @@ Biometric
 BIPOC
 Bloomberg
 Bookdown
+CCPA
 chatbot
 chatbots’
 chatGPT
@@ -59,6 +60,7 @@ FLOPs
 funders
 fyi
 GANs
+GDPR
 GDSCN
 GH
 Github


### PR DESCRIPTION
Everything needs an acronym, and all of those acronyms end up needing to be added to the dictionary