### PR TITLE
[AI Policy] Fixing course title

### DIFF
--- a/04a-AI_Policy-intro.Rmd
+++ b/04a-AI_Policy-intro.Rmd
@@ -1,11 +1,11 @@
 
-# (PART\*) Developing an AI Policy {-}
+# (PART\*) Developing AI Policy {-}
 
 ```{r, include = FALSE}
 ottrpal::set_knitr_image_path()
 ```
 
-# Introduction to Developing an AI Policy
+# Introduction
 
 This course is intended to equip you with the knowledge you need to develop an effective AI policy for your organization.
 


### PR DESCRIPTION
Decided the title needs to be Developing AI Policy, not Developing **an** AI Policy. The former matches the other courses better.