### PR TITLE
[AI Policy] Adding image to AI team

### DIFF
--- a/04c-AI_Policy-how_to_navigate.Rmd
+++ b/04c-AI_Policy-how_to_navigate.Rmd
@@ -87,6 +87,10 @@ There are multiple possible roles that you could fill, depending on your organiz
 
 **This list is a starting point for you when deciding what sort of roles you need for your own team and is not written in any particular order.** This is not an exhaustive list of all possible experts that you can gather. You should consult with your legal council, board members, and other oversight staff in order to properly address your own specialized needs.
 
+```{r, out.width = "100%", echo = FALSE}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1H3ppNjSW6OU25Z44MZWMtl1R_MH8BT-roJxiiH5Rlyk/edit#slide=id.g2a83edd52b2_0_160")
+```
+
 1. _Legal counsel_ that understands AI and the nuances of the rapidly changing laws can advise on regulations relevant to your organization. 
 
 1. _Policy and governance analysts_ can research and draft internal policies on transparency, auditability, harm mitigation, and appropriate AI uses. They can also advise and assist with compliance.

--- a/04d-AI_Policy-data_laws.Rmd
+++ b/04d-AI_Policy-data_laws.Rmd
@@ -60,8 +60,5 @@ The issue of whose fault it is when an AI system fails (and thus who is responsi
 
 As a general rule of thumb: **when in doubt, talk to your legal counsel!** They can offer you the best advice for your organization and your situation.  The information in this course is **ONLY** meant as starting point for you as you create AI guidelines for your organization. You can also seek guidance from your governance and compliance experts.
 
-```{r, out.width = "100%", echo = FALSE}
-ottrpal::include_slide("https://docs.google.com/presentation/d/1VeZiSkq6qRfUfiLMT0Y_x74vGVKBcJQ4A1oIFKncR34/edit#slide=id.g2a8454ed6ae_0_248")
-```
 
-# VIDEO Existing Laws That Apply to AI
+# VIDEO Other laws to consider


### PR DESCRIPTION
Realized I needed an image listing out the possible roles on an AI advisory team