### PR TITLE
EMH: Add intro slides to the policy bookdown

### DIFF
--- a/04a-AI_Policy-intro.Rmd
+++ b/04a-AI_Policy-intro.Rmd
@@ -17,9 +17,20 @@ AI tools are already changing how we work, and they will continue to do so for y
 
 This course is targeted toward industry and non-profit leaders and decision makers.
 
+```{r for_individuals_who, echo=FALSE, fig.alt='This course is designed for leaders, executives, and decision-makers shaping strategy and driving innovation for use or development of AI or non-technical professionals seeking to use AI and those who need to learn about the current rules and regulations around AI use and how to develop a thoughtful AI policy for their organization.', out.width = '100%'}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1w5PkqNeYlkUik4uXw30Opnzm9o-G_YQdOdjffNXlIA4/edit?slide=id.g3480d8adf7f_1_0#slide=id.g3480d8adf7f_1_0")
+```
+
+
 ## Curriculum  
 
 In this course, you’ll learn why you need an AI policy, what an AI policy might include, who can help you create and develop a policy, the state of existing AI laws, other laws and regulations that can apply to AI systems and products, and considerations for creating a strong AI policy for your organization.
+
+
+```{r topics_covered, echo=FALSE, fig.alt='You’ll learn why you need an AI policy, what an AI policy might include, who can help you create and develop a policy, the state of existing AI laws, other laws and regulations that can apply to AI systems and products, and considerations for creating a strong AI policy for your organization. You’ll also look at two real-world case studies of AI policy.', out.width = '100%', warning=FALSE}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1w5PkqNeYlkUik4uXw30Opnzm9o-G_YQdOdjffNXlIA4/edit?slide=id.g3480d8adf7f_1_8#slide=id.g3480d8adf7f_1_8")
+```
+
 
 ## Learning Objectives
 

--- a/04a-AI_Policy-intro.Rmd
+++ b/04a-AI_Policy-intro.Rmd
@@ -33,6 +33,9 @@ ottrpal::include_slide("https://docs.google.com/presentation/d/1w5PkqNeYlkUik4uX
 
 
 ## Learning Objectives
+<!--```{r learning_objectives, echo=FALSE, fig.alt='Overall Course Learning Objectives. By completing this course, learners will be able to: Understand the reasons why organizations need an AI policy. Identify the key elements of a good AI policy. Describe the roles and responsibilities of different team members involved. Identify key regulations outlined in the EU AI Act. Understand how existing industry-specific AI policies can inform your policy. Identify key legal categories relevant to AI use, including intellectual property, data privacy, and liability. Understand the limitations of relying solely on an AI policy without supporting infrastructure. Recognize the importance of involving diverse stakeholders AI policy creation. Identify strategies for building adaptable AI policies, such as living documents and separate best practices guidelines. Appreciate the role of effective training in promoting policy compliance.', out.width = '100%', warning=FALSE}
+ottrpal::include_slide("https://docs.google.com/presentation/d/1w5PkqNeYlkUik4uXw30Opnzm9o-G_YQdOdjffNXlIA4/edit?slide=id.g34ec0b7ad13_0_161#slide=id.g34ec0b7ad13_0_161")
+```-->
 
 During this course, learners will:
 


### PR DESCRIPTION
Add intro slides to the policy bookdown. Follows the convention of the changes CW and AMH (PR #131 and PR #133) have made to include slides/images about who the course is for and what the course covers to the intro section of the book.
